### PR TITLE
RPRS-2 export react context to use class component

### DIFF
--- a/packages/react/EditorProvider.tsx
+++ b/packages/react/EditorProvider.tsx
@@ -3,8 +3,8 @@ import { EditorState, Plugin } from 'prosemirror-state'
 import { EditorProps, EditorView } from 'prosemirror-view'
 import React, { createContext, useContext, useState } from 'react'
 
-const EditorStateContext = createContext<EditorState | null>(null)
-const EditorViewContext = createContext<EditorView | null>(null)
+export const EditorStateContext = createContext<EditorState | null>(null)
+export const EditorViewContext = createContext<EditorView | null>(null)
 
 export const useEditorState = (): EditorState => {
   const context = useContext(EditorStateContext)


### PR DESCRIPTION
Export react context to use class component like `Class.contextType` or `Context.Consumer`

# Class.contextType
https://ko.reactjs.org/docs/context.html#contextconsumer
```tsx
class MyClass extends React.Component {
  static editorView = EditorViewContext;
  onClick = () => {
      const view = this.context;
      if (!view) return;
      ...
      const tr = view.state.tr.replaceWith(selection.from, selection.to, node);
      view.dispatch(tr);
  }

  render() {
    ...
  }
}
```

# Context.Consumer
https://ko.reactjs.org/docs/context.html#contextconsumer
```tsx
class MyClass extends React.Component {
  onClick = (state: EditorState<typeof schema> | null, dispatch?: ((tr: Transaction) => void) | undefined, view?: EditorView<typeof schema> | null) => {
    if (!view) return;
   ...
    const tr = view?.state.tr.replaceWith(selection.from, selection.to, node);
    view.dispatch(tr);
  }

  render() {
    return (
    <EditorProvider
        schema={schema}
        plugins={plugins}
        doc={this.props.initialDoc}
      >
        <Editor />
        <EditorStateContext.Consumer>
          {(state) => 
           <EditorViewContext.Consumer>
             {(view) => (
               <button onClick={() => this.onClick(state, view?.dispatch, view)}>Button</button>
             )}
           </EditorViewContext.Consumer>
          }
        </EditorStateContext.Consumer>
      </EditorProvider>
    )
  }    
```